### PR TITLE
feat: support validation error handling during model saving

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -721,6 +721,13 @@ class Admin(BaseAdminView):
         form_data_dict = self._denormalize_wtform_data(form.data, model_view.model)
         try:
             obj = await model_view.insert_model(request, form_data_dict)
+
+        except ValidationError as exc:
+            exc.enrich_form(form)
+
+            return await self.templates.TemplateResponse(
+                request, model_view.create_template, context, status_code=400
+            )
         except Exception as e:
             logger.exception(e)
             context["error"] = str(e)

--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -40,6 +40,7 @@ from sqladmin._types import ENGINE_TYPE, SESSION_MAKER
 from sqladmin.ajax import QueryAjaxModelLoader
 from sqladmin.authentication import AuthenticationBackend, login_required
 from sqladmin.editors import collect_form_media
+from sqladmin.exceptions import ValidationError
 from sqladmin.flash import get_flashed_messages
 from sqladmin.forms import WTFORMS_ATTRS, WTFORMS_ATTRS_REVERSED
 from sqladmin.helpers import (
@@ -783,6 +784,12 @@ class Admin(BaseAdminView):
                 obj = await model_view.update_model(
                     request, pk=request.path_params["pk"], data=form_data_dict
                 )
+        except ValidationError as exc:
+            exc.enrich_form(form)
+
+            return await self.templates.TemplateResponse(
+                request, model_view.edit_template, context, status_code=400
+            )
         except Exception as e:
             logger.exception(e)
             context["error"] = str(e)

--- a/sqladmin/exceptions.py
+++ b/sqladmin/exceptions.py
@@ -8,3 +8,20 @@ class InvalidModelError(SQLAdminException):
 
 class NoConverterFound(SQLAdminException):
     pass
+
+
+class ValidationError(SQLAdminException):
+
+    def __init__(self, *form_errors, **field_errors):
+        self.form_errors = form_errors
+        self.field_errors = field_errors
+
+    def enrich_form(self, form):
+        for field_name, error in self.field_errors.items():
+            form._fields[field_name].errors.append(error)
+
+        if self.form_errors:
+            form.form_errors.append(self.form_errors)
+        elif not self.field_errors:
+            # default error
+            form.form_errors.append("Validation error")

--- a/sqladmin/exceptions.py
+++ b/sqladmin/exceptions.py
@@ -1,3 +1,8 @@
+from typing import cast
+
+from wtforms import Form
+
+
 class SQLAdminException(Exception):
     pass
 
@@ -15,12 +20,12 @@ class ValidationError(SQLAdminException):
         self.form_errors = form_errors
         self.field_errors = field_errors
 
-    def enrich_form(self, form):
+    def enrich_form(self, form: Form) -> None:
         for field_name, error in self.field_errors.items():
-            form._fields[field_name].errors.append(error)
+            cast(list[str], form._fields[field_name].errors).append(error)
 
         if self.form_errors:
-            form.form_errors.append(self.form_errors)
+            form.form_errors += self.form_errors
         elif not self.field_errors:
             # default error
             form.form_errors.append("Validation error")

--- a/sqladmin/exceptions.py
+++ b/sqladmin/exceptions.py
@@ -11,8 +11,7 @@ class NoConverterFound(SQLAdminException):
 
 
 class ValidationError(SQLAdminException):
-
-    def __init__(self, *form_errors, **field_errors):
+    def __init__(self, *form_errors: str, **field_errors: str):
         self.form_errors = form_errors
         self.field_errors = field_errors
 

--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -24,6 +24,7 @@ from starlette.applications import Starlette
 from starlette.requests import Request
 
 from sqladmin import Admin, ModelView
+from sqladmin.exceptions import ValidationError
 from tests.common import async_engine as engine
 
 pytestmark = pytest.mark.anyio
@@ -174,6 +175,12 @@ class WithDefaults(Base):
     is_active = Column(Boolean, nullable=False, default=True)
 
 
+class AsyncValidation(Base):
+    __tablename__ = "async_validation"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
 @pytest.fixture(autouse=True)
 async def prepare_database() -> AsyncGenerator[None, None]:
     async with engine.begin() as conn:
@@ -288,6 +295,16 @@ class WithDefaultsAdmin(ModelView, model=WithDefaults):
     pass
 
 
+class AsyncValidationAdmin(ModelView, model=AsyncValidation):
+    column_list = [AsyncValidation.name]
+
+    async def on_model_change(
+        self, data: dict, model: Any, is_created: bool, request: Request
+) -> None:
+        if data.get("name") == "invalid":
+            raise ValidationError(name="This name is forbidden")
+
+
 admin.add_view(UserAdmin)
 admin.add_view(AddressAdmin)
 admin.add_view(ProfileAdmin)
@@ -296,6 +313,7 @@ admin.add_view(EachRowActionAdmin)
 admin.add_view(ProductAdmin)
 admin.add_view(PersonAdmin)
 admin.add_view(WithDefaultsAdmin)
+admin.add_view(AsyncValidationAdmin)
 
 
 def _parse_ndjson_events(content: str) -> list[dict]:
@@ -1850,3 +1868,22 @@ async def test_hybrid_property(client: AsyncClient) -> None:
 
     response = await client.get("/admin/person/details/1")
     assert response.status_code == 200
+
+
+async def test_async_validation_error(client: AsyncClient):
+    # Test creation with invalid data
+    response = await client.post(
+        "/admin/async-validation/create",
+        data={"name": "invalid"},
+    )
+
+    assert response.status_code == 400, response.content
+    assert b"This name is forbidden" in response.content
+
+    # Test creation with valid data
+    response = await client.post(
+        "/admin/async-validation/create",
+        data={"name": "valid"},
+    )
+
+    assert response.status_code == 302, response.content  # Redirect after success

--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -300,7 +300,7 @@ class AsyncValidationAdmin(ModelView, model=AsyncValidation):
 
     async def on_model_change(
         self, data: dict, model: Any, is_created: bool, request: Request
-) -> None:
+    ) -> None:
         if data.get("name") == "invalid":
             raise ValidationError(name="This name is forbidden")
 
@@ -1886,4 +1886,5 @@ async def test_async_validation_error(client: AsyncClient):
         data={"name": "valid"},
     )
 
-    assert response.status_code == 302, response.content  # Redirect after success
+    # Redirect after success
+    assert response.status_code == 302, response.content


### PR DESCRIPTION
This PR enables the application to catch and display errors raised within asynchronous `on_model_change` hooks. Previously, exceptions raised in an async context during the creation or editing of models might not have been properly caught and presented to the user. Now, `ValidationError`s raised during asynchronous lifecycle hooks are correctly captured and rendered in the corresponding form fields.