### PR TITLE
fix(import): report invalid relationship values during CSV import

### DIFF
--- a/sqladmin/_import.py
+++ b/sqladmin/_import.py
@@ -109,8 +109,15 @@ def validate_import_row(
     """Coerce CSV values, then run WTForms validation on coerced form input."""
     row_data = {col: row.get(col) for col in import_columns}
 
+    # Relationship fields are not mapper columns, so they are not coerced or
+    # re-validated below: an unresolvable value is denormalized to None and would
+    # silently pass. Only those fields need the extra validation pass, so skip it
+    # entirely when every import column is a mapper column.
+    mapper_columns = sa_inspect(model).columns
+    non_mapper_columns = [col for col in import_columns if col not in mapper_columns]
+
     fallback_form = form_class(row)
-    fallback_valid = fallback_form.validate()
+    fallback_valid = fallback_form.validate() if non_mapper_columns else True
     fallback_data = denormalize_wtform_data(fallback_form.data, model)
 
     merged_import_data, row_errors = merge_import_row_data(
@@ -121,12 +128,10 @@ def validate_import_row(
     )
 
     if not fallback_valid:
-        # Relationship fields are not mapper columns, so they are not coerced or
-        # re-validated below: an unresolvable value is denormalized to None and
-        # would silently pass. Keep the errors WTForms already reported for them.
-        mapper_columns = sa_inspect(model).columns
-        for field_name, field_errors in fallback_form.errors.items():
-            if field_name in import_columns and field_name not in mapper_columns:
+        # Keep the errors WTForms already reported for the non-mapper columns.
+        for field_name in non_mapper_columns:
+            field_errors = fallback_form.errors.get(field_name)
+            if field_errors:
                 row_errors.setdefault(field_name, []).extend(field_errors)
 
     validation_form = form_class(

--- a/sqladmin/_import.py
+++ b/sqladmin/_import.py
@@ -130,6 +130,10 @@ def validate_import_row(
     if not fallback_valid:
         # Keep the errors WTForms already reported for the non-mapper columns.
         for field_name in non_mapper_columns:
+            # An empty cell is not a bad value: the pass below already reports it
+            # when the field is required, so do not double up here.
+            if row_data.get(field_name) in (None, ""):
+                continue
             field_errors = fallback_form.errors.get(field_name)
             if field_errors:
                 row_errors.setdefault(field_name, []).extend(field_errors)
@@ -139,7 +143,8 @@ def validate_import_row(
     )
     if not validation_form.validate():
         for field_name, field_errors in validation_form.errors.items():
-            row_errors.setdefault(field_name, []).extend(field_errors)
+            existing = row_errors.setdefault(field_name, [])
+            existing.extend(e for e in field_errors if e not in existing)
 
     return merged_import_data, row_errors, row_data
 

--- a/sqladmin/_import.py
+++ b/sqladmin/_import.py
@@ -113,12 +113,19 @@ def validate_import_row(
     # re-validated below: an unresolvable value is denormalized to None and would
     # silently pass. Only those fields need the extra validation pass, so skip it
     # entirely when every import column is a mapper column.
-    mapper_columns = sa_inspect(model).columns
-    non_mapper_columns = [col for col in import_columns if col not in mapper_columns]
+    mapper = sa_inspect(model)
+    non_mapper_columns = [
+        col for col in import_columns if mapper.columns.get(col) is None
+    ]
 
-    fallback_form = form_class(row)
-    fallback_valid = fallback_form.validate() if non_mapper_columns else True
-    fallback_data = denormalize_wtform_data(fallback_form.data, model)
+    if non_mapper_columns:
+        fallback_form = form_class(row)
+        fallback_valid = fallback_form.validate()
+        fallback_data = denormalize_wtform_data(fallback_form.data, model)
+    else:
+        fallback_form = None
+        fallback_valid = True
+        fallback_data = {}
 
     merged_import_data, row_errors = merge_import_row_data(
         model,
@@ -129,6 +136,7 @@ def validate_import_row(
 
     if not fallback_valid:
         # Keep the errors WTForms already reported for the non-mapper columns.
+        assert fallback_form is not None
         for field_name in non_mapper_columns:
             # An empty cell is not a bad value: the pass below already reports it
             # when the field is required, so do not double up here.
@@ -144,7 +152,11 @@ def validate_import_row(
     if not validation_form.validate():
         for field_name, field_errors in validation_form.errors.items():
             existing = row_errors.setdefault(field_name, [])
-            existing.extend(e for e in field_errors if e not in existing)
+            seen = set(existing)
+            for error in field_errors:
+                if error not in seen:
+                    existing.append(error)
+                    seen.add(error)
 
     return merged_import_data, row_errors, row_data
 

--- a/sqladmin/_import.py
+++ b/sqladmin/_import.py
@@ -118,14 +118,9 @@ def validate_import_row(
         col for col in import_columns if mapper.columns.get(col) is None
     ]
 
-    if non_mapper_columns:
-        fallback_form = form_class(row)
-        fallback_valid = fallback_form.validate()
-        fallback_data = denormalize_wtform_data(fallback_form.data, model)
-    else:
-        fallback_form = None
-        fallback_valid = True
-        fallback_data = {}
+    fallback_form = form_class(row)
+    fallback_valid = fallback_form.validate() if non_mapper_columns else True
+    fallback_data = denormalize_wtform_data(fallback_form.data, model)
 
     merged_import_data, row_errors = merge_import_row_data(
         model,
@@ -136,7 +131,6 @@ def validate_import_row(
 
     if not fallback_valid:
         # Keep the errors WTForms already reported for the non-mapper columns.
-        assert fallback_form is not None
         for field_name in non_mapper_columns:
             # An empty cell is not a bad value: the pass below already reports it
             # when the field is required, so do not double up here.

--- a/sqladmin/_import.py
+++ b/sqladmin/_import.py
@@ -110,6 +110,7 @@ def validate_import_row(
     row_data = {col: row.get(col) for col in import_columns}
 
     fallback_form = form_class(row)
+    fallback_valid = fallback_form.validate()
     fallback_data = denormalize_wtform_data(fallback_form.data, model)
 
     merged_import_data, row_errors = merge_import_row_data(
@@ -118,6 +119,15 @@ def validate_import_row(
         row_data,
         fallback_data,
     )
+
+    if not fallback_valid:
+        # Relationship fields are not mapper columns, so they are not coerced or
+        # re-validated below: an unresolvable value is denormalized to None and
+        # would silently pass. Keep the errors WTForms already reported for them.
+        mapper_columns = sa_inspect(model).columns
+        for field_name, field_errors in fallback_form.errors.items():
+            if field_name in import_columns and field_name not in mapper_columns:
+                row_errors.setdefault(field_name, []).extend(field_errors)
 
     validation_form = form_class(
         build_import_form_row(row, merged_import_data, import_columns)

--- a/sqladmin/fields.py
+++ b/sqladmin/fields.py
@@ -304,12 +304,13 @@ class QuerySelectMultipleField(QuerySelectField):
         self._formdata = list(set(valuelist))
 
     def pre_validate(self, form: Form) -> None:
+        data = self.data
         if self._invalid_formdata:
             raise ValidationError(self.gettext("Not a valid choice"))
 
-        if self.data:
+        if data:
             pk_list = [x[0] for x in self._select_data]
-            for v in self.data:
+            for v in data:
                 if v not in pk_list:  # pragma: no cover
                     raise ValidationError(self.gettext("Not a valid choice"))
 

--- a/sqladmin/helpers.py
+++ b/sqladmin/helpers.py
@@ -390,7 +390,15 @@ def build_import_form_row(
     form_row = MultiDict()
     for column_name in import_columns:
         if column_name in merged:
-            form_row[column_name] = serialize_import_value_for_form(merged[column_name])
+            value = merged[column_name]
+            if isinstance(value, (list, tuple)):
+                # A multi-select field reads one form value per selected item,
+                # so re-emit each item separately: str()-ing the list would
+                # hand the next validation pass the literal string "['1']".
+                for item in value:
+                    form_row.append(column_name, serialize_import_value_for_form(item))
+            else:
+                form_row[column_name] = serialize_import_value_for_form(value)
         else:
             form_row[column_name] = row.get(column_name) or ""
     return form_row

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -236,3 +236,16 @@ def test_textarea_field() -> None:
     form = F()
     assert "autoresize-textarea" in form.text()
     assert "chars-count-label" in form.text()
+
+
+@pytest.mark.parametrize(
+    "values, valid",
+    [(["missing"], False), (["1", "missing"], False), (["1"], True), ([], True)],
+)
+def test_multiple_select_validates_unknown_choices_on_first_pass(values, valid):
+    class F(Form):
+        select = QuerySelectMultipleField(data=[("1", "One")])
+
+    form = F(DummyData(select=values))
+    assert form.validate() is valid
+    assert form.errors == ({} if valid else {"select": ["Not a valid choice"]})

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -2,7 +2,7 @@ import enum
 
 import pytest
 from sqlalchemy import Boolean, Column, Enum, ForeignKey, Integer, String
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 from starlette.datastructures import MultiDict
 
 from sqladmin import ModelView
@@ -34,6 +34,8 @@ class ImportWidget(Base):
     profile_id = Column(Integer, ForeignKey("import_profile_validate.id"))
     active = Column(Boolean, nullable=False)
 
+    profile = relationship("ImportProfile")
+
 
 class ImportProfile(Base):
     __tablename__ = "import_profile_validate"
@@ -47,6 +49,13 @@ class ImportUserAdmin(ModelView, model=ImportUser):
 
 class ImportWidgetAdmin(ModelView, model=ImportWidget):
     column_import_list = [ImportWidget.profile_id, ImportWidget.active]
+
+
+@pytest.fixture(autouse=True)
+def prepare_database():
+    Base.metadata.create_all(engine)
+    yield
+    Base.metadata.drop_all(engine)
 
 
 def _model_view(admin_class: type[ModelView]) -> ModelView:
@@ -111,3 +120,25 @@ async def test_validate_import_row_reports_coercion_errors() -> None:
     assert merged == {"active": True}
     assert "profile_id" in errors
     assert "Invalid value" in errors["profile_id"][0]
+
+
+class ImportWidgetRelationshipAdmin(ModelView, model=ImportWidget):
+    column_import_list = [ImportWidget.active, ImportWidget.profile]
+
+
+@pytest.mark.anyio
+async def test_validate_import_row_reports_invalid_relationship_value() -> None:
+    model_view = _model_view(ImportWidgetRelationshipAdmin)
+    form_class = await model_view.scaffold_form(model_view._form_create_rules)
+    row = MultiDict([("active", "true"), ("profile", "adg34gfb13")])
+
+    merged, errors, _row_data = validate_import_row(
+        row,
+        model_view.get_import_columns(),
+        ImportWidget,
+        form_class,
+        Admin._denormalize_wtform_data,
+    )
+
+    assert merged["profile"] is None
+    assert "profile" in errors

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -203,13 +203,10 @@ async def test_validate_import_row_does_not_duplicate_relationship_errors(
 
 
 @pytest.mark.anyio
-async def test_validate_import_row_rejects_invalid_nullable_relationship_value() -> (
-    None
-):
-    model_view = _model_view(ImportWidgetRelationshipAdmin)
+async def test_validate_import_row_defaults_non_nullable_column_from_form():
+    model_view = _model_view(ImportWidgetAdmin)
     form_class = await model_view.scaffold_form(model_view._form_create_rules)
-    row = MultiDict([("active", "true"), ("profile", "adg34gfb13")])
-
+    row = MultiDict([("profile_id", "1"), ("active", "")])
     merged, errors, _row_data = validate_import_row(
         row,
         model_view.get_import_columns(),
@@ -217,6 +214,5 @@ async def test_validate_import_row_rejects_invalid_nullable_relationship_value()
         form_class,
         Admin._denormalize_wtform_data,
     )
-
-    assert merged["profile"] is None
-    assert errors == {"profile": ["Not a valid choice"]}
+    assert errors == {}
+    assert merged == {"profile_id": 1, "active": False}

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -43,6 +43,17 @@ class ImportProfile(Base):
     id = Column(Integer, primary_key=True)
 
 
+class ImportRequiredWidget(Base):
+    __tablename__ = "import_required_widget_validate"
+
+    id = Column(Integer, primary_key=True)
+    profile_id = Column(
+        Integer, ForeignKey("import_profile_validate.id"), nullable=False
+    )
+
+    profile = relationship("ImportProfile")
+
+
 class ImportUserAdmin(ModelView, model=ImportUser):
     column_import_list = [ImportUser.name, ImportUser.status]
 
@@ -141,4 +152,51 @@ async def test_validate_import_row_reports_invalid_relationship_value() -> None:
     )
 
     assert merged["profile"] is None
-    assert "profile" in errors
+    assert errors["profile"] == ["Not a valid choice"]
+
+
+@pytest.mark.anyio
+async def test_validate_import_row_accepts_valid_relationship_value() -> None:
+    with session_maker() as session:
+        session.add(ImportProfile(id=1))
+        session.commit()
+
+    model_view = _model_view(ImportWidgetRelationshipAdmin)
+    form_class = await model_view.scaffold_form(model_view._form_create_rules)
+    row = MultiDict([("active", "true"), ("profile", "1")])
+
+    merged, errors, _row_data = validate_import_row(
+        row,
+        model_view.get_import_columns(),
+        ImportWidget,
+        form_class,
+        Admin._denormalize_wtform_data,
+    )
+
+    assert errors == {}
+    assert merged["active"] is True
+    assert merged["profile"] == "1"
+
+
+class ImportRequiredWidgetRelationshipAdmin(ModelView, model=ImportRequiredWidget):
+    column_import_list = [ImportRequiredWidget.profile]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("value", ["adg34gfb13", ""])
+async def test_validate_import_row_does_not_duplicate_relationship_errors(
+    value: str,
+) -> None:
+    model_view = _model_view(ImportRequiredWidgetRelationshipAdmin)
+    form_class = await model_view.scaffold_form(model_view._form_create_rules)
+    row = MultiDict([("profile", value)])
+
+    _merged, errors, _row_data = validate_import_row(
+        row,
+        model_view.get_import_columns(),
+        ImportRequiredWidget,
+        form_class,
+        Admin._denormalize_wtform_data,
+    )
+
+    assert errors["profile"] == ["Not a valid choice"]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -200,3 +200,23 @@ async def test_validate_import_row_does_not_duplicate_relationship_errors(
     )
 
     assert errors["profile"] == ["Not a valid choice"]
+
+
+@pytest.mark.anyio
+async def test_validate_import_row_rejects_invalid_nullable_relationship_value() -> (
+    None
+):
+    model_view = _model_view(ImportWidgetRelationshipAdmin)
+    form_class = await model_view.scaffold_form(model_view._form_create_rules)
+    row = MultiDict([("active", "true"), ("profile", "adg34gfb13")])
+
+    merged, errors, _row_data = validate_import_row(
+        row,
+        model_view.get_import_columns(),
+        ImportWidget,
+        form_class,
+        Admin._denormalize_wtform_data,
+    )
+
+    assert merged["profile"] is None
+    assert errors == {"profile": ["Not a valid choice"]}

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -54,6 +54,23 @@ class ImportRequiredWidget(Base):
     profile = relationship("ImportProfile")
 
 
+class ImportTag(Base):
+    __tablename__ = "import_tag_validate"
+
+    id = Column(Integer, primary_key=True)
+    label = Column(String)
+    post_id = Column(Integer, ForeignKey("import_post_validate.id"))
+
+
+class ImportPost(Base):
+    __tablename__ = "import_post_validate"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String)
+
+    tags = relationship("ImportTag")
+
+
 class ImportUserAdmin(ModelView, model=ImportUser):
     column_import_list = [ImportUser.name, ImportUser.status]
 
@@ -200,6 +217,33 @@ async def test_validate_import_row_does_not_duplicate_relationship_errors(
     )
 
     assert errors["profile"] == ["Not a valid choice"]
+
+
+class ImportPostTagsAdmin(ModelView, model=ImportPost):
+    column_import_list = [ImportPost.title, ImportPost.tags]
+
+
+@pytest.mark.anyio
+async def test_validate_import_row_round_trips_valid_multi_select_value() -> None:
+    with session_maker() as session:
+        session.add(ImportTag(id=1, label="t1"))
+        session.commit()
+
+    model_view = _model_view(ImportPostTagsAdmin)
+    form_class = await model_view.scaffold_form(model_view._form_create_rules)
+    row = MultiDict([("title", "good"), ("tags", "1")])
+
+    merged, errors, _row_data = validate_import_row(
+        row,
+        model_view.get_import_columns(),
+        ImportPost,
+        form_class,
+        Admin._denormalize_wtform_data,
+    )
+
+    assert errors == {}
+    assert merged["title"] == "good"
+    assert merged["tags"] == ["1"]
 
 
 @pytest.mark.anyio

--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -239,6 +239,11 @@ class UserAdmin(ModelView, model=User):
     can_import = True
 
 
+class UserRelationshipImportAdmin(ModelView, model=User):
+    can_import = True
+    column_import_list = [User.name, User.profile]
+
+
 class AddressAdmin(ModelView, model=Address):
     column_list = ["id", "user_id", "user", "user.profile.id"]
     column_searchable_list = [Address.id]
@@ -299,6 +304,7 @@ class WithDefaultsAdmin(ModelView, model=WithDefaults):
 
 
 admin.add_view(UserAdmin)
+admin.add_view(UserRelationshipImportAdmin)
 admin.add_view(AddressAdmin)
 admin.add_view(ProfileAdmin)
 admin.add_view(MovieAdmin)
@@ -1255,6 +1261,33 @@ async def test_import_csv_file(client: AsyncClient) -> None:
     assert users[1].name == "USER_2"
     assert users[1].id == 2
     assert users[1].status == Status.DEACTIVE
+
+
+async def test_import_csv_reports_invalid_relationship_value() -> None:
+    local_app = Starlette()
+    local_admin = Admin(app=local_app, engine=engine)
+    local_admin.add_view(UserRelationshipImportAdmin)
+    transport = ASGITransport(app=local_app)
+    async with AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as local_client:
+        response = await local_client.post(
+            "/admin/user/import",
+            files={
+                "csvfile": (
+                    "user.csv",
+                    b"name,profile\r\nUSER_1,missing\r\n",
+                    "text/csv",
+                )
+            },
+        )
+
+    assert response.status_code == 200
+    result = _parse_ndjson_events(response.text)[-1]
+    assert result["type"] == "result"
+    assert result["ok"] is False
+    assert result["aborted"] is True
+    assert result["missed_rows"][0]["errors"] == {"profile": ["Not a valid choice"]}
 
 
 async def test_import_csv_button(client: AsyncClient) -> None:

--- a/tests/test_views/test_view_async.py
+++ b/tests/test_views/test_view_async.py
@@ -239,11 +239,6 @@ class UserAdmin(ModelView, model=User):
     can_import = True
 
 
-class UserRelationshipImportAdmin(ModelView, model=User):
-    can_import = True
-    column_import_list = [User.name, User.profile]
-
-
 class AddressAdmin(ModelView, model=Address):
     column_list = ["id", "user_id", "user", "user.profile.id"]
     column_searchable_list = [Address.id]
@@ -304,7 +299,6 @@ class WithDefaultsAdmin(ModelView, model=WithDefaults):
 
 
 admin.add_view(UserAdmin)
-admin.add_view(UserRelationshipImportAdmin)
 admin.add_view(AddressAdmin)
 admin.add_view(ProfileAdmin)
 admin.add_view(MovieAdmin)
@@ -1263,10 +1257,17 @@ async def test_import_csv_file(client: AsyncClient) -> None:
     assert users[1].status == Status.DEACTIVE
 
 
-async def test_import_csv_reports_invalid_relationship_value() -> None:
+@pytest.mark.parametrize("relationship_name", ["profile", "addresses"])
+async def test_import_csv_reports_invalid_relationship_value(
+    relationship_name: str,
+) -> None:
+    class RelationshipImportAdmin(ModelView, model=User):
+        can_import = True
+        column_import_list = ["name", relationship_name]
+
     local_app = Starlette()
     local_admin = Admin(app=local_app, engine=engine)
-    local_admin.add_view(UserRelationshipImportAdmin)
+    local_admin.add_view(RelationshipImportAdmin)
     transport = ASGITransport(app=local_app)
     async with AsyncClient(
         transport=transport, base_url="http://testserver"
@@ -1276,7 +1277,7 @@ async def test_import_csv_reports_invalid_relationship_value() -> None:
             files={
                 "csvfile": (
                     "user.csv",
-                    b"name,profile\r\nUSER_1,missing\r\n",
+                    f"name,{relationship_name}\r\nUSER_1,missing\r\n".encode(),
                     "text/csv",
                 )
             },
@@ -1287,7 +1288,14 @@ async def test_import_csv_reports_invalid_relationship_value() -> None:
     assert result["type"] == "result"
     assert result["ok"] is False
     assert result["aborted"] is True
-    assert result["missed_rows"][0]["errors"] == {"profile": ["Not a valid choice"]}
+    assert result["missed_rows"][0]["errors"] == {
+        relationship_name: ["Not a valid choice"]
+    }
+
+    async with session_maker() as session:
+        assert (
+            await session.execute(select(User).where(User.name == "USER_1"))
+        ).scalar_one_or_none() is None
 
 
 async def test_import_csv_button(client: AsyncClient) -> None:


### PR DESCRIPTION
Closes #1114

Relationship fields are not mapper columns, so `merge_import_row_data()` neither coerces nor re-validates them. WTForms does reject an unresolvable value with `Not a valid choice`, but it denormalizes it to `None`, and the second validation pass then sees an empty (valid) field — so the row imported as valid with the relationship silently dropped and `continue_on_error=False` never aborted the import.

`validate_import_row()` now keeps the errors the fallback form already reported for import columns that are not mapper columns. Regression test added in `tests/test_import.py`; it fails on `main` (no `profile` error) and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
