### PR TITLE
fix: fixed file selection widget

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import io
 import logging
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
@@ -838,7 +837,7 @@ class Admin(BaseAdminView):
                 request, model_view.edit_template, context
             )
 
-        form_data = await self._handle_form_data(request, model)
+        form_data = await self._handle_form_data(request)
         form = Form(form_data)
         context["form"] = form
 
@@ -1037,30 +1036,12 @@ class Admin(BaseAdminView):
         return request.url_for("admin:create", identity=identity)
 
     @staticmethod
-    async def _handle_form_data(request: Request, obj: Any = None) -> FormData:
-        """
-        Handle form data and modify in case of UploadFile.
-        This is needed since in edit page
-        there's no way to show current file of object.
-        """
-
+    async def _handle_form_data(request: Request) -> FormData:
         form = await request.form()
         form_data: list[tuple[str, str | UploadFile]] = []
         for key, value in form.multi_items():
-            if not isinstance(value, UploadFile):
-                form_data.append((key, value))
-                continue
+            form_data.append((key, value))
 
-            should_clear = form.get(key + "_checkbox")
-            empty_upload = len(await value.read(1)) != 1
-            await value.seek(0)
-            if should_clear:
-                form_data.append((key, UploadFile(io.BytesIO(b""))))
-            elif empty_upload and obj and getattr(obj, key):
-                f = getattr(obj, key)  # In case of update, imitate UploadFile
-                form_data.append((key, UploadFile(filename=f.name, file=f.open())))
-            else:
-                form_data.append((key, value))
         return FormData(form_data)
 
     @staticmethod

--- a/sqladmin/statics/js/main.js
+++ b/sqladmin/statics/js/main.js
@@ -699,3 +699,51 @@ function formatImportTemplate(template, values) {
     if (name !== null) rememberCategory(name, false);
   });
 })();
+
+// Event for the clear button of the optional file input
+$(document).on('click', '[data-role="clear-file-input"]', function () {
+    const fieldId = $(this).data('field-id');
+    if (!fieldId) return;
+
+    const $fileInput = $(fieldId);
+    if (!$fileInput.length || !$fileInput.is('input[type="file"]')) return;
+
+    $fileInput.wrap('<form>').closest('form').get(0).reset();
+    $fileInput.unwrap();
+});
+
+// Function for loading a file from base64 to a value in the file input
+function handlePreloadedFile(base64Data, fieldId, filename) {
+  const binaryString = window.atob(base64Data);
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  const blob = new Blob([bytes], { type: 'application/octet-stream'});
+  const file = new File([blob], filename, { type: 'application/octet-stream' });
+
+  const fileInput = document.getElementById(fieldId);
+  const dt = new DataTransfer();
+  dt.items.add(file);
+  fileInput.files = dt.files;
+}
+
+// Event for searching all file inputs and loading files from base64
+$(document).ready(async function() {
+  const $containers = $('.file-input-container');
+
+  const promises = $containers.map(function() {
+    const $container = $(this);
+
+    const base64Data = $container.data('base64');
+    const fieldId = $container.data('field-id');
+    const filename = $container.data('filename');
+
+    if (base64Data && fieldId && filename) {
+      return handlePreloadedFile(base64Data, fieldId, filename);
+    }
+  }).get();
+
+  await Promise.all(promises);
+});

--- a/sqladmin/widgets.py
+++ b/sqladmin/widgets.py
@@ -1,9 +1,10 @@
 # mypy: disable-error-code="override"
-
+import base64
 import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from fastapi_storages import StorageFile
 from markupsafe import Markup, escape
 from wtforms import Field, SelectFieldBase, widgets
 from wtforms.widgets import html_params
@@ -131,27 +132,51 @@ class FileInputWidget(widgets.FileInput):
     """
 
     def __call__(self, field: Field, **kwargs: Any) -> Markup:
+        filename = ""
+        base64_bytes = ""
+        current_value = Markup("")
+
+        if isinstance(field.data, StorageFile):
+            filename = field.data.name
+            current_value = Markup("Currently: {value}").format(value=field.data.path)
+            base64_bytes = base64.b64encode(field.data.open().read()).decode("utf-8")
+
+        input_html = super().__call__(field, **kwargs)
+
         if not field.flags.required:
-            checkbox_id = f"{field.id}_checkbox"
-            checkbox_label = Markup(
-                '<label class="form-check-label" for="{}">Clear</label>'
-            ).format(checkbox_id)
-
-            checkbox_input = Markup(
-                '<input class="form-check-input" type="checkbox" id="{}" name="{}">'  # noqa: E501
-            ).format(checkbox_id, checkbox_id)
-            checkbox = Markup('<div class="form-check">{}{}</div>').format(
-                checkbox_input, checkbox_label
-            )
+            clear_button = Markup(
+                "<button "
+                'type="button" '
+                'class="btn btn-secondary" '
+                'data-field-id="#{field_id}" '
+                'data-role="clear-file-input">'
+                '<i class="fa-solid fa-xmark"></i>'
+                "</button>"
+            ).format(field_id=field.id)
         else:
-            checkbox = Markup()
+            clear_button = Markup()
 
-        if field.data:
-            current_value = Markup("<p>Currently: {}</p>").format(field.data)
-            field.flags.required = False
-            return current_value + checkbox + super().__call__(field, **kwargs)
-
-        return super().__call__(field, **kwargs)
+        return Markup(
+            "<div "
+            'class="file-input-container" '
+            'data-base64="{base64}" '
+            'data-field-id="{field_id}" '
+            'data-filename="{filename}" '
+            ">"
+            '<div class="row m-0 p-0 pb-1">{current_value}</div>'
+            '<div class="row m-0 p-0">'
+            '<div class="col m-0 p-0">{input_html}</div>'
+            '<div class="col m-0 p-0 col-auto">{clear_button}</div>'
+            "</div>"
+            "</div>"
+        ).format(
+            base64=base64_bytes,
+            field_id=field.id,
+            filename=filename,
+            current_value=current_value,
+            input_html=input_html,
+            clear_button=clear_button,
+        )
 
 
 class BooleanInputWidget(widgets.CheckboxInput):

--- a/sqladmin/widgets.py
+++ b/sqladmin/widgets.py
@@ -138,7 +138,9 @@ class FileInputWidget(widgets.FileInput):
 
         if isinstance(field.data, StorageFile):
             filename = field.data.name
-            current_value = Markup("Currently: {value}").format(value=field.data.path)
+            current_value = Markup("Currently: {value}").format(
+                value=escape(field.data.path)
+            )
             base64_bytes = base64.b64encode(field.data.open().read()).decode("utf-8")
 
         input_html = super().__call__(field, **kwargs)
@@ -152,7 +154,7 @@ class FileInputWidget(widgets.FileInput):
                 'data-role="clear-file-input">'
                 '<i class="fa-solid fa-xmark"></i>'
                 "</button>"
-            ).format(field_id=field.id)
+            ).format(field_id=escape(field.id))
         else:
             clear_button = Markup()
 
@@ -170,9 +172,9 @@ class FileInputWidget(widgets.FileInput):
             "</div>"
             "</div>"
         ).format(
-            base64=base64_bytes,
-            field_id=field.id,
-            filename=filename,
+            base64=escape(base64_bytes),
+            field_id=escape(field.id),
+            filename=escape(filename),
             current_value=current_value,
             input_html=input_html,
             clear_button=clear_button,

--- a/tests/test_file_upload.py
+++ b/tests/test_file_upload.py
@@ -10,7 +10,6 @@ from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from sqladmin import Admin, ModelView
-from sqladmin.fields import FileField
 from tests.common import sync_engine as engine
 
 Base = declarative_base()  # type: Any
@@ -42,7 +41,7 @@ def client() -> Generator[TestClient, None, None]:
 
 
 class UserAdmin(ModelView, model=User):
-    form_overrides = {User.file: FileField, User.optional_file: FileField}
+    pass
 
 
 admin.add_view(UserAdmin)
@@ -62,10 +61,12 @@ def test_create_form_fields(client: TestClient) -> None:
         '<input class="form-control" id="file" name="file" required type="file">'
         in response.text
     )
+    assert 'data-field-id="#file"' not in response.text
     assert (
-        '<input class="form-control" id="optional_file" name="optional_file" type="file">'  # noqa: E501
-        in response.text
-    )
+        '<input class="form-control" id="optional_file" '
+        'name="optional_file" type="file">'
+    ) in response.text
+    assert 'data-field-id="#optional_file"' in response.text
 
 
 def test_create_form_post(client: TestClient) -> None:
@@ -108,9 +109,7 @@ def test_create_form_update(client: TestClient) -> None:
     assert user.optional_file.open().read() == b"zyx"
 
     files = {"file": ("file.txt", b"abc")}
-    client.post(
-        "/admin/user/edit/1", files=files, data={"optional_file_checkbox": "true"}
-    )
+    client.post("/admin/user/edit/1", files=files)
 
     user = _query_user()
     assert user.file.name == "file.txt"
@@ -128,11 +127,7 @@ def test_get_form_update(client: TestClient) -> None:
     response = client.get("/admin/user/edit/1")
 
     assert response.text.count("Currently:") == 2
-    assert '<input class="form-check-input" type="checkbox"' in response.text
-    assert (
-        '<label class="form-check-label" for="optional_file_checkbox">Clear</label>'
-        in response.text
-    )
+    assert 'data-field-id="#optional_file"' in response.text
 
     files = {"file": ("file.txt", b"abc")}
     client.post("/admin/user/edit/1", files=files)


### PR DESCRIPTION
## Create form
### An optional file can now be deselected even during creation. This is necessary in cases where the user has selected a file and then changed their mind about saving it.
<img width="1587" height="429" alt="Screenshot from 2026-08-07 18-23-23" src="https://github.com/user-attachments/assets/d007024f-8eb3-4c03-822d-a276636fed41" />
<img width="1587" height="429" alt="Screenshot from 2026-08-07 18-23-46" src="https://github.com/user-attachments/assets/06de3828-3a6e-4bbc-98db-37213d41228b" />

## Edit form
### The file was automatically pulled into the input, as if the user had selected it. Previously, the input would have remained empty.
<img width="1587" height="490" alt="Screenshot from 2026-08-07 18-24-03" src="https://github.com/user-attachments/assets/406400e3-f0f2-452a-a9a0-c033736aff91" />

### We delete the existing value of the optional field using the button
<img width="1587" height="490" alt="Screenshot from 2026-08-07 18-24-11" src="https://github.com/user-attachments/assets/b206399b-8fb9-4941-89cb-41dfbc13f195" />

### The optional file was successfully deleted.
<img width="1587" height="490" alt="Screenshot from 2026-08-07 18-24-23" src="https://github.com/user-attachments/assets/62ac207f-7aba-4b21-82f5-f3df4390fc7b" />

## Other
* Legacy conditions in the `_handle_form_data` function are no longer needed