### PR TITLE
fix: handle translated save button labels in create/edit redirects

### DIFF
--- a/sqladmin/application.py
+++ b/sqladmin/application.py
@@ -852,7 +852,9 @@ class Admin(BaseAdminView):
 
         form_data_dict = self._denormalize_wtform_data(form.data, model)
         try:
-            if model_view.save_as and form_data.get("save") == "Save as new":
+            if model_view.save_as and self._save_button_clicked(
+                form_data, "Save as new"
+            ):
                 obj = await model_view.insert_model(request, form_data_dict)
             else:
                 obj = await model_view.update_model(
@@ -1023,18 +1025,31 @@ class Admin(BaseAdminView):
         identity = request.path_params["identity"]
         identifier = get_object_identifier(obj)
 
-        if form.get("save") == "Save":
+        if Admin._save_button_clicked(form, "Save"):
             url = URL(str(request.url_for("admin:list", identity=identity)))
             if request.url.query:
                 url = url.replace(query=request.url.query)
             return url
 
-        if form.get("save") == "Save and continue editing" or (
-            form.get("save") == "Save as new" and model_view.save_as_continue
+        if Admin._save_button_clicked(form, "Save and continue editing") or (
+            Admin._save_button_clicked(form, "Save as new")
+            and model_view.save_as_continue
         ):
             return request.url_for("admin:edit", identity=identity, pk=identifier)
 
         return request.url_for("admin:create", identity=identity)
+
+    @staticmethod
+    def _save_button_clicked(form: FormData, label: str) -> bool:
+        """Return whether the submit button ``label`` was pressed.
+
+        The create/edit templates render the submit buttons via gettext, so in
+        non-English locales the submitted ``save`` value is the translated
+        label. Compare against both the English literal and the active-locale
+        translation.
+        """
+        save = form.get("save")
+        return save in (label, gettext(label))
 
     @staticmethod
     async def _handle_form_data(request: Request, obj: Any = None) -> FormData:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -14,6 +14,7 @@ from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from sqladmin import Admin, ModelView
+from sqladmin.i18n import DEFAULT_LOCALE, set_locale
 from tests.common import sync_engine as engine
 
 Base = declarative_base()  # type: ignore
@@ -226,6 +227,49 @@ def test_get_save_redirect_url():
     # go to fixed edit/create pages and should ignore it.
     response = client.post("/user?page=3", data={"save": "Save and continue editing"})
     assert response.text == "http://testserver/admin/user/edit/1"
+
+
+def test_get_save_redirect_url_localized():
+    """The submit button labels are rendered via gettext (create/edit
+    templates), so in non-English locales the submitted ``save`` value is the
+    translated label. The redirect must be resolved the same way."""
+
+    async def index(request: Request):
+        obj = User(id=1)
+        form_data = await request.form()
+        # LocaleMiddleware would have resolved the locale before the handler.
+        set_locale("ru")
+        url = admin.get_save_redirect_url(request, form_data, admin.views[0], obj)
+        set_locale(DEFAULT_LOCALE)
+        return Response(str(url))
+
+    app = Starlette(
+        routes=[
+            Route("/{identity}", index, methods=["POST"]),
+        ]
+    )
+    admin = Admin(app=app, engine=engine)
+
+    class UserAdmin(ModelView, model=User):
+        save_as = True
+
+    admin.add_view(UserAdmin)
+
+    client = TestClient(app)
+
+    response = client.post("/user", data={"save": "Сохранить"})
+    assert response.text == "http://testserver/admin/user/list"
+
+    response = client.post(
+        "/user", data={"save": "Сохранить и продолжить редактирование"}
+    )
+    assert response.text == "http://testserver/admin/user/edit/1"
+
+    response = client.post("/user", data={"save": "Сохранить как новое"})
+    assert response.text == "http://testserver/admin/user/edit/1"
+
+    response = client.post("/user", data={"save": "Сохранить и добавить ещё"})
+    assert response.text == "http://testserver/admin/user/create"
 
 
 def test_build_category_menu():


### PR DESCRIPTION
In non-English locales, submitting an edit or create form in SQLAdmin redirects the user to the empty create page instead of the expected list page. Additionally, the "Save as new" button on the edit page updates the current record instead of creating a copy. Saving itself always succeeds — the record is written to the database — only the post-save navigation (and the copy semantics) are wrong.

This only reproduces when the admin UI is rendered in a non-English locale (I18nConfig(default_locale="ru"), or when the locale is negotiated from the Accept-Language header / language cookie / ?lang= query parameter). With the default "en" locale everything works as expected.

Add a small private helper on Admin that matches the submitted button value against both the English literal and the active-locale translation:

```python
@staticmethod
def _save_button_clicked(form: FormData, label: str) -> bool:
    """Return whether the submit button ``label`` was pressed.

    The create/edit templates render the submit buttons via gettext, so in
    non-English locales the submitted ``save`` value is the translated
    label. Compare against both the English literal and the active-locale
    translation.
    """
    save = form.get("save")
    return save in (label, gettext(label))
```

gettext resolves against the request locale set by LocaleMiddleware — the same locale that was used to render the button in the first place — so the comparison always matches what the user actually clicked. The English literal is kept in the comparison, so the behavior for the default locale (and for apps without i18n) is unchanged.

