### PR TITLE
Clamp page before building LIMIT/OFFSET, not after

### DIFF
--- a/sqladmin/models.py
+++ b/sqladmin/models.py
@@ -1079,6 +1079,13 @@ class ModelView(BaseView, metaclass=ModelViewMeta):
             request, select(func.count()).select_from(stmt.subquery())
         )
 
+        # Clamp before building the LIMIT/OFFSET, not after: an oversized
+        # page number times page_size can overflow what the DB driver's
+        # integer binding accepts (SQLite in particular), so the offset
+        # needs a valid page to work with rather than raising before
+        # Pagination ever gets a chance to clamp it itself.
+        page = min(page, max(1, count // page_size + 1))
+
         stmt = stmt.limit(page_size).offset((page - 1) * page_size)
         rows = await self._run_query(stmt)
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -282,6 +282,11 @@ def test_validate_page_and_page_size():
     response = client.get("/admin/user/list?page=10000")
     assert response.status_code == 200
 
+    # A page number this large used to overflow the integer binding on the
+    # LIMIT/OFFSET before Pagination ever got a chance to clamp it.
+    response = client.get("/admin/user/list?page=99999999999999999999")
+    assert response.status_code == 200
+
     response = client.get("/admin/user/list?page=aaaa")
     assert response.status_code == 400
 


### PR DESCRIPTION
Fixes #1136.

Pagination already knows how to clamp an out-of-range page (`__post_init__` in `sqladmin/pagination.py` runs `min(page, max(1, count // page_size + 1))`), but it only sees the page number after `ModelView.list` has already built the SQL statement and sent it to the database. Something like `?page=99999999999999999999` never reaches that clamp: it multiplies out to a number bigger than SQLite's integer binding can hold, and the query fails with a raw `OverflowError` before a 500 response ever gets near Pagination's own logic.

I reproduced the exact request from the report against a local SQLite-backed admin and confirmed the traceback matches (`OverflowError: Python int too large to convert to SQLite INTEGER`, in `SQLiteDialect_pysqlite.do_execute`). The fix applies the same clamp formula right after the count query, before the limit/offset gets computed, so by the time the statement reaches the database the page number is already sane - same numbers Pagination would have produced anyway, just early enough to matter.

Extended the existing `test_validate_page_and_page_size` test with the oversized page case rather than writing a separate test, since it exercises the same code path as the existing assertions there. Confirmed it fails with the original `OverflowError` on unpatched code and passes with the fix (checked both ways locally). Full suite: 595 passed, 5 skipped (all pre-existing, unrelated to this change).